### PR TITLE
Fix table of contents and references formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .edge-debug-profile/
+test.md


### PR DESCRIPTION
Enhancements to markdown processing:

* [`contentScript.js`](diffhunk://#diff-c89f55ed43133253050dbce66bfd2c8a4f6280615dbaa582b7efbe3104a79614R119-R185): Added the `reformatTableOfContents` function to format the table of contents with proper indentation based on section levels.
* [`contentScript.js`](diffhunk://#diff-c89f55ed43133253050dbce66bfd2c8a4f6280615dbaa582b7efbe3104a79614R119-R185): Added the `preserveReferencesLineBreaks` function to maintain line breaks in reference sections, ensuring better readability.